### PR TITLE
feat(blog): add responsive posts listing with reusable Card components

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,67 @@
+import { PostCard } from '@/components/blog/PostCard'
+import { BlogPost } from '@/types'
+
+const posts: BlogPost[] = [
+    {
+        id: '1',
+        title: 'Cómo optimizamos granjas para rendimiento constante',
+        author: 'Triskcraft Team',
+        created_at: '2026-01-12T10:00:00.000Z',
+        excerpt:
+            'En esta guía revisamos el proceso completo para mejorar rendimiento en granjas técnicas sin perder eficiencia por chunks o sincronización.',
+        slug: 'optimizamos-granjas-rendimiento',
+    },
+    {
+        id: '2',
+        title: 'Diseño decorativo funcional para bases técnicas',
+        author: 'Vugx',
+        created_at: '2026-01-29T10:00:00.000Z',
+        excerpt:
+            'Combinamos estética y utilidad para que tus salas de máquinas luzcan limpias, claras y preparadas para futuras ampliaciones.',
+        slug: 'diseno-decorativo-funcional-bases-tecnicas',
+    },
+    {
+        id: '3',
+        title: 'Guía rápida para empezar en Triskcraft',
+        author: 'Staff Triskcraft',
+        created_at: '2026-02-18T10:00:00.000Z',
+        excerpt:
+            'Todo lo que necesitas para dar tus primeros pasos: reglas de convivencia, enfoque técnico y recursos recomendados para progresar.',
+        slug: 'guia-rapida-empezar-triskcraft',
+    },
+    {
+        id: '4',
+        title: 'Tour técnico: aprendizajes de nuestro último proyecto',
+        author: 'Severalplot4310',
+        created_at: '2026-03-03T10:00:00.000Z',
+        excerpt:
+            'Compartimos aciertos y errores durante la construcción de uno de nuestros proyectos más ambiciosos con redstone avanzada.',
+        slug: 'tour-tecnico-ultimo-proyecto',
+    },
+]
+
+export default function BlogPage() {
+    return (
+        <section className='relative mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10'>
+            <header className='rounded-3xl border border-triskgold/20 bg-black/30 p-8 text-center shadow-xl shadow-black/25'>
+                <p className='mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-triskgold'>
+                    Blog
+                </p>
+                <h1 className='text-4xl font-bold text-triskgold drop-shadow-lg'>
+                    Novedades de la comunidad
+                </h1>
+                <p className='mx-auto mt-4 max-w-3xl text-base leading-relaxed text-white/75 md:text-lg'>
+                    Artículos sobre Minecraft técnico, redstone y diseño
+                    decorativo. Un espacio para compartir avances, ideas y
+                    aprendizajes del servidor.
+                </p>
+            </header>
+
+            <div className='grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3'>
+                {posts.map(post => (
+                    <PostCard key={post.id} post={post} />
+                ))}
+            </div>
+        </section>
+    )
+}

--- a/src/components/blog/PostCard.tsx
+++ b/src/components/blog/PostCard.tsx
@@ -1,0 +1,42 @@
+import { BlogPost } from '@/types'
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
+import { LinkButton } from '@/components/ui/button'
+
+interface PostCardProps {
+    post: BlogPost
+}
+
+function formatPublishedDate(value: string) {
+    const date = new Date(value)
+
+    return new Intl.DateTimeFormat('es-CL', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(date)
+}
+
+export function PostCard({ post }: PostCardProps) {
+    return (
+        <Card className='h-full'>
+            <CardHeader>
+                <p className='text-sm font-medium text-white/60'>
+                    {post.author} · {formatPublishedDate(post.created_at)}
+                </p>
+                <h2 className='text-2xl font-bold leading-tight text-white'>
+                    {post.title}
+                </h2>
+            </CardHeader>
+
+            <CardContent className='mt-4'>
+                <p className='text-base leading-relaxed text-white/80'>
+                    {post.excerpt}
+                </p>
+            </CardContent>
+
+            <CardFooter className='mt-4'>
+                <LinkButton href={`/blog/${post.slug}`}>Leer más</LinkButton>
+            </CardFooter>
+        </Card>
+    )
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -64,6 +64,9 @@ export function Navbar() {
                         <li className='transition hover:text-triskgold/100 hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
                             <Link href={app.members()}>Miembros</Link>
                         </li>
+                        <li className='transition hover:text-triskgold/100 hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
+                            <Link href='/blog'>Blog</Link>
+                        </li>
                         <li>
                             <Link
                                 href='https://discord.com/invite/VJQJRZehTG'

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+interface LinkButtonProps {
+    href: string
+    children: ReactNode
+}
+
+export function LinkButton({ href, children }: LinkButtonProps) {
+    return (
+        <Link
+            href={href}
+            className='inline-flex items-center gap-2 rounded-full border border-triskgold/60 px-4 py-2 text-sm font-semibold text-triskgold transition hover:-translate-y-0.5 hover:bg-triskgold/10'
+        >
+            {children}
+        </Link>
+    )
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react'
+
+interface CardProps {
+    children: ReactNode
+    className?: string
+}
+
+export function Card({ children, className = '' }: CardProps) {
+    return (
+        <article
+            className={`rounded-2xl border border-triskgold/20 bg-black/35 p-6 shadow-lg shadow-black/20 backdrop-blur-sm ${className}`}
+        >
+            {children}
+        </article>
+    )
+}
+
+export function CardHeader({ children, className = '' }: CardProps) {
+    return <header className={`space-y-2 ${className}`}>{children}</header>
+}
+
+export function CardContent({ children, className = '' }: CardProps) {
+    return <div className={`space-y-4 ${className}`}>{children}</div>
+}
+
+export function CardFooter({ children, className = '' }: CardProps) {
+    return <footer className={`pt-2 ${className}`}>{children}</footer>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,12 @@ export interface Member {
         url: string
     }>
 }
+
+export interface BlogPost {
+    id: string
+    title: string
+    author: string
+    created_at: string
+    excerpt: string
+    slug: string
+}


### PR DESCRIPTION
### Motivation
- Añadir una página `/blog` con una maquetación coherente con el resto del sitio para mostrar entradas en formato tarjeta y facilitar la publicación de contenidos de la comunidad. 
- Reutilizar patrones visuales ya presentes (bordes, paleta y espaciado) creando primitivas UI simples que permitan consistencia y reutilización.

### Description
- Se añadió la nueva página de listado en `src/app/blog/page.tsx` con un encabezado y una grilla responsive (`grid-cols-1` en móvil, `md:grid-cols-2`, `xl:grid-cols-3`).
- Se creó `src/components/blog/PostCard.tsx` que renderiza cada post como tarjeta con `title`, `author`, `created_at` (formateada), `excerpt` y un enlace `Leer más` a `/blog/[slug]`.
- Se implementaron componentes UI reutilizables inspirados en el estilo shadcn: `Card`, `CardHeader`, `CardContent`, `CardFooter` en `src/components/ui/card.tsx` y el botón-enlace `LinkButton` en `src/components/ui/button.tsx`.
- Se añadió la interfaz `BlogPost` en `src/types.ts` con la forma solicitada (`id`, `title`, `author`, `created_at`, `excerpt`, `slug`).
- Se actualizó el `Navbar` en `src/components/layout/Navbar.tsx` para incluir un enlace al nuevo `/blog`.

### Testing
- Ejecuté `npm run lint` como verificación automática, pero la tarea falló debido a que el binario `next` no estaba disponible en el entorno (`sh: 1: next: not found`).
- Intenté una captura con Playwright de `http://127.0.0.1:3000/blog` para validar visualmente, pero la petición devolvió `ERR_EMPTY_RESPONSE` porque no había servidor local en ejecución; la captura no se generó.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae5b2e0bec832a85cfc7daaa5d0837)