### PR TITLE
[codex] Use API env for modpack download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # TriskCraftSMP-Web
 
+## Variables de entorno
+
+```env
+NEXT_PUBLIC_API_URL="https://api.triskcraft.com"
+```
+

--- a/src/actions/members.actions.ts
+++ b/src/actions/members.actions.ts
@@ -1,8 +1,9 @@
 'use server'
+import { API_URL } from '@/constant/api'
 import type { Member } from '@/types'
 
 export async function getActiveMembersAction() {
-    const req = await fetch('https://api.triskcraft.com/v1/members')
+    const req = await fetch(`${API_URL}/v1/members`)
     if (req.status !== 200) return []
     const members = (await req.json()) as Member[]
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { AiOutlineMenu, AiOutlineClose } from 'react-icons/ai'
 import app from '@eliyya/type-routes'
+import { MODPACK_DOWNLOAD_URL } from '@/constant/api'
 
 export function Navbar() {
     const [isOpen, setIsOpen] = useState(false)
@@ -76,8 +77,9 @@ export function Navbar() {
                             </Link>
 
                             <Link
-                                href='public/mods/pack-mods-triskcraftsmp.rar'
+                                href={MODPACK_DOWNLOAD_URL}
                                 download
+                                prefetch={false}
                                 className='ml-0.5 inline-flex items-center gap-2 rounded-r-full bg-triskgold px-4 py-2 text-triskgreen shadow-lg shadow-triskgold/30 transition hover:-translate-y-0.5 hover:shadow-xl'
                             >
                                 Mods

--- a/src/constant/api.ts
+++ b/src/constant/api.ts
@@ -1,0 +1,7 @@
+const DEFAULT_API_URL = 'https://api.triskcraft.com'
+
+export const API_URL = (
+    process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL
+).replace(/\/$/, '')
+
+export const MODPACK_DOWNLOAD_URL = `${API_URL}/files/web/pack-mods-triskcraftsmp.rar`


### PR DESCRIPTION
## Summary
- Add a shared API URL constant sourced from NEXT_PUBLIC_API_URL with a production fallback.
- Route member API calls through the shared API URL.
- Update the navbar Mods button to download the modpack from the API instead of public assets.
- Document NEXT_PUBLIC_API_URL in the README.

## Validation
- npm run build