### PR TITLE
Agrega validación de PR para la web

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,13 @@ jobs:
                       sudo -u web git reset --hard origin/main
 
                       echo "Verificando pnpm..."
-                      sudo -Hu web pnpm --version
+                      sudo -u web pnpm --version
 
                       echo "Instalando dependencias..."
-                      sudo -Hu web pnpm install --frozen-lockfile
+                      sudo -u web env CI=true pnpm install --frozen-lockfile
 
                       echo "Generando build..."
-                      sudo -Hu web pnpm run build
+                      sudo -u web pnpm run build
 
                       echo "Reiniciando servicio..."
                       sudo systemctl restart triskweb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,11 @@ jobs:
               env:
                   CI: true
 
+            - name: Lint
+              run: pnpm run lint
+
+            - name: Check formatting
+              run: pnpm run format:check
+
             - name: Build
               run: pnpm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test Web
+
+on:
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24.14.0
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 11.5.2
+                  run_install: false
+
+            - name: Verify pnpm
+              run: pnpm --version
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+              env:
+                  CI: true
+
+            - name: Build
+              run: pnpm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,17 @@ jobs:
               run: pnpm run lint
 
             - name: Check formatting
-              run: pnpm run format:check
+              shell: bash
+              run: |
+                  git fetch origin ${{ github.base_ref }} --depth=1
+                  files="$(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}" HEAD | grep -E '\.(css|js|jsx|json|md|mjs|ts|tsx|ya?ml)$' || true)"
+
+                  if [ -z "$files" ]; then
+                      echo "No formatted files changed."
+                      exit 0
+                  fi
+
+                  echo "$files" | xargs pnpm exec prettier --check
 
             - name: Build
               run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "dev": "next dev --turbopack",
         "build": "next build --turbopack",
         "start": "next start",
-        "lint": "next lint"
+        "lint": "next lint",
+        "format:check": "prettier --check ."
     },
     "dependencies": {
         "@eliyya/type-routes": "2.5.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev": "next dev --turbopack",
         "build": "next build --turbopack",
         "start": "next start",
-        "lint": "next lint",
+        "lint": "eslint .",
         "format:check": "prettier --check ."
     },
     "dependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+packages:
+    - .
+
+allowBuilds:
+    '@eliyya/type-routes': false
+    sharp: true
+    unrs-resolver: true


### PR DESCRIPTION
## Resumen
- Ajusta el deploy para ejecutar `pnpm install --frozen-lockfile` en modo CI.
- Configura `allowBuilds` de pnpm para permitir `sharp` y `unrs-resolver`, e ignorar `@eliyya/type-routes`.
- Agrega un workflow de pruebas para PRs hacia `main` que instala dependencias, revisa formato, ejecuta lint y compila la web.

## Contexto
El objetivo es detectar antes del merge fallos del pipeline relacionados con pnpm, scripts de build aprobados y el build de Next.js.

## Validación
- `CI=true pnpm install --frozen-lockfile`
- `pnpm run build`
