### PR TITLE
Añadir inicio de sesión con Discord en la web

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "react-icons": "5.6.0",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "zustand": "5.0.14"
     },
     "devDependencies": {
         "@eslint/eslintrc": "3.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
             remark-gfm:
                 specifier: ^4.0.1
                 version: 4.0.1
+            zustand:
+                specifier: 5.0.14
+                version: 5.0.14(@types/react@19.2.14)(react@19.2.6)
         devDependencies:
             '@eslint/eslintrc':
                 specifier: 3.3.5
@@ -4038,6 +4041,27 @@ packages:
                 integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
             }
 
+    zustand@5.0.14:
+        resolution:
+            {
+                integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==,
+            }
+        engines: { node: '>=12.20.0' }
+        peerDependencies:
+            '@types/react': '>=18.0.0'
+            immer: '>=9.0.6'
+            react: '>=18.0.0'
+            use-sync-external-store: '>=1.2.0'
+        peerDependenciesMeta:
+            '@types/react':
+                optional: true
+            immer:
+                optional: true
+            react:
+                optional: true
+            use-sync-external-store:
+                optional: true
+
     zwitch@2.0.4:
         resolution:
             {
@@ -6809,5 +6833,10 @@ snapshots:
             zod: 4.4.3
 
     zod@4.4.3: {}
+
+    zustand@5.0.14(@types/react@19.2.14)(react@19.2.6):
+        optionalDependencies:
+            '@types/react': 19.2.14
+            react: 19.2.6
 
     zwitch@2.0.4: {}

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,0 +1,77 @@
+import { API_URL } from '@/constant/api'
+import { NextRequest, NextResponse } from 'next/server'
+
+const CLIENT_ID = 'triskcraft-web'
+const SESSION_MAX_AGE = 7 * 24 * 60 * 60
+
+export async function GET(request: NextRequest) {
+    const code = request.nextUrl.searchParams.get('code')
+    const state = request.nextUrl.searchParams.get('state')
+    const codeVerifier = request.cookies.get('oauth-code-verifier')?.value
+    const expectedState = request.cookies.get('oauth-state')?.value
+    const homeUrl = new URL('/', request.url)
+
+    if (!code || !state || state !== expectedState || !codeVerifier) {
+        homeUrl.searchParams.set('auth_error', 'invalid_callback')
+        return NextResponse.redirect(homeUrl)
+    }
+
+    const redirectUri = new URL('/api/auth/callback', request.url).toString()
+    const tokenResponse = await fetch(`${API_URL}/oauth/token`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri: redirectUri,
+            client_id: CLIENT_ID,
+            code_verifier: codeVerifier,
+        }),
+        cache: 'no-store',
+    })
+
+    if (!tokenResponse.ok) {
+        homeUrl.searchParams.set('auth_error', 'token_exchange_failed')
+        return NextResponse.redirect(homeUrl)
+    }
+
+    const token = (await tokenResponse.json()) as {
+        access_token: string
+        expires_in: number
+        refresh_token?: string
+    }
+    const response = NextResponse.redirect(homeUrl)
+    const sessionCookieOptions = {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax' as const,
+        path: '/',
+    }
+
+    response.cookies.set('triskcraft-access-token', token.access_token, {
+        ...sessionCookieOptions,
+        maxAge: token.expires_in,
+    })
+    if (token.refresh_token) {
+        response.cookies.set(
+            'triskcraft-refresh-token',
+            token.refresh_token,
+            {
+                ...sessionCookieOptions,
+                maxAge: SESSION_MAX_AGE,
+            },
+        )
+    }
+    response.cookies.set('oauth-code-verifier', '', {
+        path: '/api/auth',
+        maxAge: 0,
+    })
+    response.cookies.set('oauth-state', '', {
+        path: '/api/auth',
+        maxAge: 0,
+    })
+
+    return response
+}

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -55,14 +55,10 @@ export async function GET(request: NextRequest) {
         maxAge: token.expires_in,
     })
     if (token.refresh_token) {
-        response.cookies.set(
-            'triskcraft-refresh-token',
-            token.refresh_token,
-            {
-                ...sessionCookieOptions,
-                maxAge: SESSION_MAX_AGE,
-            },
-        )
+        response.cookies.set('triskcraft-refresh-token', token.refresh_token, {
+            ...sessionCookieOptions,
+            maxAge: SESSION_MAX_AGE,
+        })
     }
     response.cookies.set('oauth-code-verifier', '', {
         path: '/api/auth',

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,40 @@
+import { API_URL } from '@/constant/api'
+import { createHash, randomBytes } from 'node:crypto'
+import { NextRequest, NextResponse } from 'next/server'
+
+const CLIENT_ID = 'triskcraft-web'
+const COOKIE_MAX_AGE = 10 * 60
+
+export function GET(request: NextRequest) {
+    const codeVerifier = randomBytes(32).toString('base64url')
+    const codeChallenge = createHash('sha256')
+        .update(codeVerifier)
+        .digest('base64url')
+    const state = randomBytes(32).toString('base64url')
+    const redirectUri = new URL('/api/auth/callback', request.url).toString()
+    const authorizeUrl = new URL('/oauth/authorize', API_URL)
+
+    authorizeUrl.search = new URLSearchParams({
+        response_type: 'code',
+        client_id: CLIENT_ID,
+        redirect_uri: redirectUri,
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+        scope: 'openid identify',
+        state,
+    }).toString()
+
+    const response = NextResponse.redirect(authorizeUrl)
+    const cookieOptions = {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax' as const,
+        path: '/api/auth',
+        maxAge: COOKIE_MAX_AGE,
+    }
+
+    response.cookies.set('oauth-code-verifier', codeVerifier, cookieOptions)
+    response.cookies.set('oauth-state', state, cookieOptions)
+
+    return response
+}

--- a/src/app/api/auth/status/route.ts
+++ b/src/app/api/auth/status/route.ts
@@ -35,7 +35,10 @@ export async function GET(request: NextRequest) {
     }
 
     if (refreshToken) {
-        const redirectUri = new URL('/api/auth/callback', request.url).toString()
+        const redirectUri = new URL(
+            '/api/auth/callback',
+            request.url,
+        ).toString()
         const refreshResponse = await fetch(`${API_URL}/oauth/refresh`, {
             method: 'POST',
             headers: {

--- a/src/app/api/auth/status/route.ts
+++ b/src/app/api/auth/status/route.ts
@@ -1,0 +1,110 @@
+import { API_URL } from '@/constant/api'
+import { NextRequest, NextResponse } from 'next/server'
+
+const CLIENT_ID = 'triskcraft-web'
+const SESSION_MAX_AGE = 7 * 24 * 60 * 60
+
+async function getSessionUser(accessToken: string) {
+    const response = await fetch(`${API_URL}/oauth/me`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+        cache: 'no-store',
+    })
+
+    if (!response.ok) return null
+
+    return response.json()
+}
+
+export async function GET(request: NextRequest) {
+    const accessToken = request.cookies.get('triskcraft-access-token')?.value
+    const refreshToken = request.cookies.get('triskcraft-refresh-token')?.value
+
+    if (!accessToken && !refreshToken) {
+        return NextResponse.json({ authenticated: false })
+    }
+
+    if (accessToken) {
+        const user = await getSessionUser(accessToken)
+
+        if (user) {
+            return NextResponse.json({ authenticated: true, user })
+        }
+    }
+
+    if (refreshToken) {
+        const redirectUri = new URL('/api/auth/callback', request.url).toString()
+        const refreshResponse = await fetch(`${API_URL}/oauth/refresh`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                grant_type: 'refresh_token',
+                redirect_uri: redirectUri,
+                client_id: CLIENT_ID,
+                refresh_token: refreshToken,
+            }),
+            cache: 'no-store',
+        })
+
+        if (refreshResponse.ok) {
+            const token = (await refreshResponse.json()) as {
+                access_token: string
+                expires_in: number
+                refresh_token: string
+            }
+            const user = await getSessionUser(token.access_token)
+
+            if (!user) {
+                return clearSessionResponse()
+            }
+
+            const response = NextResponse.json({
+                authenticated: true,
+                user,
+            })
+            const cookieOptions = {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === 'production',
+                sameSite: 'lax' as const,
+                path: '/',
+            }
+
+            response.cookies.set(
+                'triskcraft-access-token',
+                token.access_token,
+                {
+                    ...cookieOptions,
+                    maxAge: token.expires_in,
+                },
+            )
+            response.cookies.set(
+                'triskcraft-refresh-token',
+                token.refresh_token,
+                {
+                    ...cookieOptions,
+                    maxAge: SESSION_MAX_AGE,
+                },
+            )
+            return response
+        }
+    }
+
+    return clearSessionResponse()
+}
+
+function clearSessionResponse() {
+    const response = NextResponse.json({ authenticated: false })
+    response.cookies.set('triskcraft-access-token', '', {
+        path: '/',
+        maxAge: 0,
+    })
+    response.cookies.set('triskcraft-refresh-token', '', {
+        path: '/',
+        maxAge: 0,
+    })
+    return response
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,16 +1,26 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { AiOutlineMenu, AiOutlineClose } from 'react-icons/ai'
 import app from '@eliyya/type-routes'
-import { MODPACK_DOWNLOAD_URL } from '@/constant/api'
+import {
+    DISCORD_GUILD_URL,
+    MODPACK_DOWNLOAD_URL,
+} from '@/constant/api'
+import { useSessionStore } from '@/stores/session'
 
 export function Navbar() {
     const [isOpen, setIsOpen] = useState(false)
+    const isAuthenticated = useSessionStore(state => state.isAuthenticated)
+    const loadSession = useSessionStore(state => state.loadSession)
+
+    useEffect(() => {
+        void loadSession()
+    }, [loadSession])
 
     return (
-        <header className='border-triskgold/30 from-triskgreen via-triskmint to-triskgreen text-triskgold sticky top-0 z-50 border-b bg-gradient-to-r shadow-xl backdrop-blur-md'>
+        <header className='border-triskgold/30 from-triskgreen via-triskmint to-triskgreen text-triskgold sticky top-0 z-50 border-b bg-linear-to-r shadow-xl backdrop-blur-md'>
             <div className='mx-auto flex max-w-6xl items-center justify-between px-4 py-3'>
                 <div className='flex items-center gap-3'>
                     <Link
@@ -48,35 +58,45 @@ export function Navbar() {
                 <nav
                     className={`absolute top-full left-0 w-full bg-transparent shadow-none transition-all duration-300 md:static md:w-auto md:overflow-visible md:bg-transparent md:shadow-none ${
                         isOpen ?
-                            'from-triskgreen/50 via-triskmint/50 to-triskgreen/50 max-h-96 bg-gradient-to-r'
+                            'from-triskgreen/50 via-triskmint/50 to-triskgreen/50 max-h-96 bg-linear-to-r'
                         :   'max-h-0 overflow-hidden opacity-0 md:max-h-none md:opacity-100'
                     }`}
                 >
                     <ul className='flex flex-col items-start gap-4 px-6 py-4 text-lg font-semibold md:flex-row md:items-center md:gap-10 md:px-0 md:py-0'>
-                        <li className='hover:text-triskgold/100 transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
+                        <li className='hover:text-triskgold transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
                             <Link href={app()}>Inicio</Link>
                         </li>
-                        <li className='hover:text-triskgold/100 transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
+                        <li className='hover:text-triskgold transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
                             <Link href={app.us()}>Nosotros</Link>
                         </li>
-                        <li className='hover:text-triskgold/100 transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
+                        <li className='hover:text-triskgold transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
                             <Link href={app.projects()}>Proyectos</Link>
                         </li>
-                        <li className='hover:text-triskgold/100 transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
+                        <li className='hover:text-triskgold transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
                             <Link href={app.members()}>Miembros</Link>
                         </li>
-                        <li className='hover:text-triskgold/100 transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
+                        <li className='hover:text-triskgold transition hover:drop-shadow-[0_0_10px_rgba(214,175,63,0.55)]'>
                             <Link href={app.blog()}>Blog</Link>
                         </li>
                         <li>
                             <Link
-                                href='https://discord.com/invite/VJQJRZehTG'
-                                target='_blank'
-                                rel='noopener noreferrer'
+                                href={
+                                    isAuthenticated ?
+                                        DISCORD_GUILD_URL
+                                    :   '/api/auth/login'
+                                }
+                                target={isAuthenticated ? '_blank' : undefined}
+                                rel={
+                                    isAuthenticated ?
+                                        'noopener noreferrer'
+                                    :   undefined
+                                }
                                 prefetch={false}
                                 className='bg-triskgold text-triskgreen shadow-triskgold/30 mr-0.5 inline-flex items-center gap-2 rounded-l-full px-4 py-2 shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl'
                             >
-                                Únete al Discord
+                                {isAuthenticated ?
+                                    'Ir al gremio'
+                                :   'Únete con Discord'}
                             </Link>
 
                             <Link

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -4,10 +4,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { AiOutlineMenu, AiOutlineClose } from 'react-icons/ai'
 import app from '@eliyya/type-routes'
-import {
-    DISCORD_GUILD_URL,
-    MODPACK_DOWNLOAD_URL,
-} from '@/constant/api'
+import { DISCORD_GUILD_URL, MODPACK_DOWNLOAD_URL } from '@/constant/api'
 import { useSessionStore } from '@/stores/session'
 
 export function Navbar() {
@@ -81,9 +78,9 @@ export function Navbar() {
                         <li>
                             <Link
                                 href={
-                                    isAuthenticated ?
-                                        DISCORD_GUILD_URL
-                                    :   '/api/auth/login'
+                                    isAuthenticated ? DISCORD_GUILD_URL : (
+                                        '/api/auth/login'
+                                    )
                                 }
                                 target={isAuthenticated ? '_blank' : undefined}
                                 rel={

--- a/src/constant/api.ts
+++ b/src/constant/api.ts
@@ -5,3 +5,6 @@ export const API_URL = (
 ).replace(/\/$/, '')
 
 export const MODPACK_DOWNLOAD_URL = `${API_URL}/files/web/pack-mods-triskcraftsmp.rar`
+
+export const DISCORD_GUILD_URL =
+    'https://discord.com/channels/1202732116102877246'

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand'
+
+export interface SessionUser {
+    sub: string
+    iss: string
+    aud: string
+    exp: number
+    id: string
+    rank: string
+    created_at: number
+    discord_user: {
+        id: string
+        username: string
+    }
+}
+
+interface SessionResponse {
+    authenticated: boolean
+    user?: SessionUser
+}
+
+interface SessionStore {
+    session: SessionUser | null
+    isAuthenticated: boolean
+    isLoading: boolean
+    loadSession: () => Promise<void>
+    clearSession: () => void
+}
+
+export const useSessionStore = create<SessionStore>((set, get) => ({
+    session: null,
+    isAuthenticated: false,
+    isLoading: false,
+    loadSession: async () => {
+        if (get().isLoading) return
+
+        set({ isLoading: true })
+
+        try {
+            const response = await fetch('/api/auth/status', {
+                cache: 'no-store',
+            })
+            const { authenticated, user } =
+                (await response.json()) as SessionResponse
+
+            set({
+                session: authenticated ? (user ?? null) : null,
+                isAuthenticated: authenticated,
+                isLoading: false,
+            })
+        } catch {
+            set({
+                session: null,
+                isAuthenticated: false,
+                isLoading: false,
+            })
+        }
+    },
+    clearSession: () =>
+        set({
+            session: null,
+            isAuthenticated: false,
+            isLoading: false,
+        }),
+}))


### PR DESCRIPTION
## Resumen

- añade el flujo de inicio de sesión OAuth con PKCE desde rutas internas de Next.js
- intercambia y renueva tokens mediante cookies HTTP-only
- expone el estado de sesión y el usuario autenticado mediante un store de Zustand
- adapta la navegación para iniciar sesión con Discord o abrir directamente el gremio cuando la sesión está activa
- centraliza la URL pública del gremio y añade las dependencias necesarias

## Motivo

La web necesitaba integrarse con el OAuth del bot para autenticar usuarios de Discord de forma segura y reflejar el estado de sesión en la interfaz.

## Validación

- `pnpm lint` pasa con 11 advertencias existentes y sin errores
- `pnpm build` compila y valida TypeScript, pero el prerender de `/members` falla con `ECONNREFUSED` porque la API requerida no está disponible durante la validación local
