### PR TITLE
Fix Discord OAuth callback URL

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,8 +1,4 @@
-import {
-    API_URL,
-    AUTH_CALLBACK_URL,
-    NEXT_PUBLIC_SITE_URL,
-} from '@/constant/api'
+import { API_URL } from '@/constant/api'
 import { NextRequest, NextResponse } from 'next/server'
 
 const CLIENT_ID = 'triskcraft-web'
@@ -13,13 +9,14 @@ export async function GET(request: NextRequest) {
     const state = request.nextUrl.searchParams.get('state')
     const codeVerifier = request.cookies.get('oauth-code-verifier')?.value
     const expectedState = request.cookies.get('oauth-state')?.value
-    const homeUrl = new URL('/', NEXT_PUBLIC_SITE_URL)
+    const homeUrl = new URL('/', request.url)
 
     if (!code || !state || state !== expectedState || !codeVerifier) {
         homeUrl.searchParams.set('auth_error', 'invalid_callback')
         return NextResponse.redirect(homeUrl)
     }
 
+    const redirectUri = new URL('/api/auth/callback', request.url).toString()
     const tokenResponse = await fetch(`${API_URL}/oauth/token`, {
         method: 'POST',
         headers: {
@@ -28,7 +25,7 @@ export async function GET(request: NextRequest) {
         body: JSON.stringify({
             grant_type: 'authorization_code',
             code,
-            redirect_uri: AUTH_CALLBACK_URL,
+            redirect_uri: redirectUri,
             client_id: CLIENT_ID,
             code_verifier: codeVerifier,
         }),

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,4 +1,8 @@
-import { API_URL } from '@/constant/api'
+import {
+    API_URL,
+    AUTH_CALLBACK_URL,
+    NEXT_PUBLIC_SITE_URL,
+} from '@/constant/api'
 import { NextRequest, NextResponse } from 'next/server'
 
 const CLIENT_ID = 'triskcraft-web'
@@ -9,14 +13,13 @@ export async function GET(request: NextRequest) {
     const state = request.nextUrl.searchParams.get('state')
     const codeVerifier = request.cookies.get('oauth-code-verifier')?.value
     const expectedState = request.cookies.get('oauth-state')?.value
-    const homeUrl = new URL('/', request.url)
+    const homeUrl = new URL('/', NEXT_PUBLIC_SITE_URL)
 
     if (!code || !state || state !== expectedState || !codeVerifier) {
         homeUrl.searchParams.set('auth_error', 'invalid_callback')
         return NextResponse.redirect(homeUrl)
     }
 
-    const redirectUri = new URL('/api/auth/callback', request.url).toString()
     const tokenResponse = await fetch(`${API_URL}/oauth/token`, {
         method: 'POST',
         headers: {
@@ -25,7 +28,7 @@ export async function GET(request: NextRequest) {
         body: JSON.stringify({
             grant_type: 'authorization_code',
             code,
-            redirect_uri: redirectUri,
+            redirect_uri: AUTH_CALLBACK_URL,
             client_id: CLIENT_ID,
             code_verifier: codeVerifier,
         }),

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,22 +1,23 @@
-import { API_URL, AUTH_CALLBACK_URL } from '@/constant/api'
+import { API_URL, NEXT_PUBLIC_SITE_URL } from '@/constant/api'
 import { createHash, randomBytes } from 'node:crypto'
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 
 const CLIENT_ID = 'triskcraft-web'
 const COOKIE_MAX_AGE = 10 * 60
 
-export function GET() {
+export function GET(request: NextRequest) {
     const codeVerifier = randomBytes(32).toString('base64url')
     const codeChallenge = createHash('sha256')
         .update(codeVerifier)
         .digest('base64url')
     const state = randomBytes(32).toString('base64url')
+    const redirectUri = new URL('/api/auth/callback', quest.url).toString()
     const authorizeUrl = new URL('/oauth/authorize', API_URL)
 
     authorizeUrl.search = new URLSearchParams({
         response_type: 'code',
         client_id: CLIENT_ID,
-        redirect_uri: AUTH_CALLBACK_URL,
+        redirect_uri: redirectUri,
         code_challenge: codeChallenge,
         code_challenge_method: 'S256',
         scope: 'openid identify',

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,23 +1,22 @@
-import { API_URL, NEXT_PUBLIC_SITE_URL } from '@/constant/api'
+import { API_URL, AUTH_CALLBACK_URL } from '@/constant/api'
 import { createHash, randomBytes } from 'node:crypto'
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 
 const CLIENT_ID = 'triskcraft-web'
 const COOKIE_MAX_AGE = 10 * 60
 
-export function GET(request: NextRequest) {
+export function GET() {
     const codeVerifier = randomBytes(32).toString('base64url')
     const codeChallenge = createHash('sha256')
         .update(codeVerifier)
         .digest('base64url')
     const state = randomBytes(32).toString('base64url')
-    const redirectUri = new URL('/api/auth/callback', quest.url).toString()
     const authorizeUrl = new URL('/oauth/authorize', API_URL)
 
     authorizeUrl.search = new URLSearchParams({
         response_type: 'code',
         client_id: CLIENT_ID,
-        redirect_uri: redirectUri,
+        redirect_uri: AUTH_CALLBACK_URL,
         code_challenge: codeChallenge,
         code_challenge_method: 'S256',
         scope: 'openid identify',

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,4 +1,4 @@
-import { API_URL } from '@/constant/api'
+import { API_URL, NEXT_PUBLIC_SITE_URL } from '@/constant/api'
 import { createHash, randomBytes } from 'node:crypto'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -11,7 +11,7 @@ export function GET(request: NextRequest) {
         .update(codeVerifier)
         .digest('base64url')
     const state = randomBytes(32).toString('base64url')
-    const redirectUri = new URL('/api/auth/callback', request.url).toString()
+    const redirectUri = new URL('/api/auth/callback', quest.url).toString()
     const authorizeUrl = new URL('/oauth/authorize', API_URL)
 
     authorizeUrl.search = new URLSearchParams({

--- a/src/app/api/auth/status/route.ts
+++ b/src/app/api/auth/status/route.ts
@@ -1,4 +1,4 @@
-import { API_URL, AUTH_CALLBACK_URL } from '@/constant/api'
+import { API_URL } from '@/constant/api'
 import { NextRequest, NextResponse } from 'next/server'
 
 const CLIENT_ID = 'triskcraft-web'
@@ -35,6 +35,10 @@ export async function GET(request: NextRequest) {
     }
 
     if (refreshToken) {
+        const redirectUri = new URL(
+            '/api/auth/callback',
+            request.url,
+        ).toString()
         const refreshResponse = await fetch(`${API_URL}/oauth/refresh`, {
             method: 'POST',
             headers: {
@@ -42,7 +46,7 @@ export async function GET(request: NextRequest) {
             },
             body: JSON.stringify({
                 grant_type: 'refresh_token',
-                redirect_uri: AUTH_CALLBACK_URL,
+                redirect_uri: redirectUri,
                 client_id: CLIENT_ID,
                 refresh_token: refreshToken,
             }),

--- a/src/app/api/auth/status/route.ts
+++ b/src/app/api/auth/status/route.ts
@@ -1,4 +1,4 @@
-import { API_URL } from '@/constant/api'
+import { API_URL, AUTH_CALLBACK_URL } from '@/constant/api'
 import { NextRequest, NextResponse } from 'next/server'
 
 const CLIENT_ID = 'triskcraft-web'
@@ -35,10 +35,6 @@ export async function GET(request: NextRequest) {
     }
 
     if (refreshToken) {
-        const redirectUri = new URL(
-            '/api/auth/callback',
-            request.url,
-        ).toString()
         const refreshResponse = await fetch(`${API_URL}/oauth/refresh`, {
             method: 'POST',
             headers: {
@@ -46,7 +42,7 @@ export async function GET(request: NextRequest) {
             },
             body: JSON.stringify({
                 grant_type: 'refresh_token',
-                redirect_uri: redirectUri,
+                redirect_uri: AUTH_CALLBACK_URL,
                 client_id: CLIENT_ID,
                 refresh_token: refreshToken,
             }),

--- a/src/constant/api.ts
+++ b/src/constant/api.ts
@@ -9,10 +9,4 @@ export const MODPACK_DOWNLOAD_URL = `${API_URL}/files/web/pack-mods-triskcraftsm
 export const DISCORD_GUILD_URL =
     'https://discord.com/channels/1202732116102877246'
 
-export const NEXT_PUBLIC_SITE_URL =
-    process.env.NEXT_PUBLIC_SITE_URL ?? 'https://triskcraft.com'
-
-export const AUTH_CALLBACK_URL = new URL(
-    '/api/auth/callback',
-    NEXT_PUBLIC_SITE_URL,
-).toString()
+export const NEXT_PUBLIC_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://triskcraft.com'

--- a/src/constant/api.ts
+++ b/src/constant/api.ts
@@ -8,3 +8,5 @@ export const MODPACK_DOWNLOAD_URL = `${API_URL}/files/web/pack-mods-triskcraftsm
 
 export const DISCORD_GUILD_URL =
     'https://discord.com/channels/1202732116102877246'
+
+export const NEXT_PUBLIC_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://triskcraft.com'

--- a/src/constant/api.ts
+++ b/src/constant/api.ts
@@ -9,4 +9,10 @@ export const MODPACK_DOWNLOAD_URL = `${API_URL}/files/web/pack-mods-triskcraftsm
 export const DISCORD_GUILD_URL =
     'https://discord.com/channels/1202732116102877246'
 
-export const NEXT_PUBLIC_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://triskcraft.com'
+export const NEXT_PUBLIC_SITE_URL =
+    process.env.NEXT_PUBLIC_SITE_URL ?? 'https://triskcraft.com'
+
+export const AUTH_CALLBACK_URL = new URL(
+    '/api/auth/callback',
+    NEXT_PUBLIC_SITE_URL,
+).toString()


### PR DESCRIPTION
## Summary
- Fix the Discord OAuth login redirect by using the configured public callback URL consistently.
- Use the same callback URL for token exchange and refresh requests.
- Fixes #53.

## Checks
- pnpm lint
- pnpm build