### PR TITLE
Migrar despliegue de la web a Vercel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,37 +5,44 @@ on:
         branches:
             - main
 
+concurrency:
+    group: production
+    cancel-in-progress: true
+
 jobs:
     deploy:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Deploy via SSH
-              uses: appleboy/ssh-action@v1.0.3
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
               with:
-                  host: ${{ secrets.VPS_HOST }}
-                  username: deploy
-                  key: ${{ secrets.VPS_SSH_KEY }}
-                  script: |
-                      set -euxo pipefail
+                  node-version: 24
+                  cache: pnpm
 
-                      echo "Deploy iniciado..."
-                      cd /opt/web/triskweb
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
 
-                      echo "Actualizando código..."
-                      sudo -u web git fetch origin
-                      sudo -u web git reset --hard origin/main
+            - name: Pull Vercel project settings
+              run: pnpm dlx vercel@latest pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+              env:
+                  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+                  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
-                      echo "Verificando pnpm..."
-                      sudo -u web pnpm --version
+            - name: Build
+              run: pnpm dlx vercel@latest build --prod --token=${{ secrets.VERCEL_TOKEN }}
+              env:
+                  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+                  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
-                      echo "Instalando dependencias..."
-                      sudo -u web env CI=true pnpm install --frozen-lockfile
-
-                      echo "Generando build..."
-                      sudo -u web pnpm run build
-
-                      echo "Reiniciando servicio..."
-                      sudo systemctl restart triskweb
-
-                      echo "Deploy completado."
+            - name: Deploy to Vercel
+              run: pnpm dlx vercel@latest deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+              env:
+                  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+                  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tsconfig.tsbuildinfo
 .env*
 public/mods/pack-mods-triskcraftsmp.rar
 triskcraft.code-workspace
+
+.vercel


### PR DESCRIPTION
## Resumen

Migra el despliegue de producción desde una VPS a Vercel.

### Cambios
- Sustituye el workflow basado en SSH por un workflow de Vercel.
- Usa `vercel pull`, `vercel build --prod` y `vercel deploy --prebuilt --prod`.
- Añade `.vercel` al `.gitignore`.

### Validación
- El despliegue deja de depender del servidor VPS y pasa a realizarse mediante Vercel.